### PR TITLE
Rename endpoint

### DIFF
--- a/src/Http/Controllers/Swagger/InvoicesApiContract.php
+++ b/src/Http/Controllers/Swagger/InvoicesApiContract.php
@@ -9,7 +9,7 @@ interface InvoicesApiContract
 {
     /**
      * @OA\Get(
-     *     path="/api/invoices/{id}",
+     *     path="/api/order-invoices/{id}",
      *     summary="Get invoice identified by a given id identifier of order",
      *     tags={"Invoices"},
      *     security={

--- a/src/routes.php
+++ b/src/routes.php
@@ -3,6 +3,6 @@
 use EscolaLms\Invoices\Http\Controllers\InvoicesApiController;
 use Illuminate\Support\Facades\Route;
 
-Route::group(['prefix' => 'api/invoices'], function () {
+Route::group(['prefix' => 'api/order-invoices'], function () {
     Route::get('/{id}', [InvoicesApiController::class, 'read']);
 });

--- a/tests/Api/InvoicesApiTest.php
+++ b/tests/Api/InvoicesApiTest.php
@@ -53,35 +53,35 @@ class InvoicesApiTest extends TestCase
 
     public function testCanReadInvoices(): void
     {
-        $response = $this->actingAs($this->user, 'api')->getJson('api/invoices/'.$this->order->getKey());
+        $response = $this->actingAs($this->user, 'api')->getJson('api/order-invoices/'.$this->order->getKey());
 
         $response->assertOk();
     }
 
     public function testCannotFindMissingOrder(): void
     {
-        $response = $this->actingAs($this->user, 'api')->getJson('api/invoices/999999');
+        $response = $this->actingAs($this->user, 'api')->getJson('api/order-invoices/999999');
 
         $response->assertStatus(404);
     }
 
     public function testAdminCanReadInvoicesByOrderId(): void
     {
-        $response = $this->actingAs($this->admin, 'api')->getJson('api/invoices/'.$this->order->getKey());
+        $response = $this->actingAs($this->admin, 'api')->getJson('api/order-invoices/'.$this->order->getKey());
 
         $response->assertOk();
     }
 
     public function testOtherUsersCannotReadInvoicesOtherUser(): void
     {
-        $response = $this->actingAs($this->user2, 'api')->getJson('api/invoices/'.$this->order->getKey());
+        $response = $this->actingAs($this->user2, 'api')->getJson('api/order-invoices/'.$this->order->getKey());
 
         $response->assertForbidden();
     }
 
     public function testGuestCannotReadInvoices(): void
     {
-        $response = $this->getJson('api/invoices/'.$this->order->getKey());
+        $response = $this->getJson('api/order-invoices/'.$this->order->getKey());
 
         $response->assertForbidden();
     }


### PR DESCRIPTION
`/api/invoices/{id}` is already used in [Fakturownia-Integration](https://github.com/EscolaLMS/Fakturownia-Integration/blob/main/src/routes.php#L6)